### PR TITLE
Avoid duplicate futures

### DIFF
--- a/src/upgrade_type_hints/main.py
+++ b/src/upgrade_type_hints/main.py
@@ -28,7 +28,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     for filename in args.filenames:
         # Fetch all typing imports and type annotations
-        annotation_list, imports = find_annotations_and_imports_in_file(filename)
+        annotation_list, imports, futures_import_found = find_annotations_and_imports_in_file(filename)
 
         # Get all *relevant* type annotations (annotations we want to substitute)
         native_types, imported_types = check_if_types_need_substitution(annotation_list, imports)
@@ -38,7 +38,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
         if native_types or imported_types and imports_to_delete:
             print(f'Fixing {filename}')
-            update_file(filename, args.futures, native_types, imported_types, imports_to_delete)
+            update_file(
+                filename=filename,
+                futures=args.futures,
+                native_types=native_types,
+                imported_types=imported_types,
+                imports_to_delete=imports_to_delete,
+                futures_import_found=futures_import_found,
+            )
             return_value = 1
 
     return exit(return_value)

--- a/src/upgrade_type_hints/update.py
+++ b/src/upgrade_type_hints/update.py
@@ -62,7 +62,12 @@ def remove_import(operation, content):
 
 
 def update_file(
-    filename: str, futures: bool, native_types: list, imported_types: list, imports_to_delete: list
+    filename: str,
+    futures: bool,
+    native_types: list,
+    imported_types: list,
+    imports_to_delete: list,
+    futures_import_found: bool,
 ) -> None:
     """
     Reads a file, removes imports and updates types, then writes back to it.
@@ -89,7 +94,7 @@ def update_file(
 
     # Filter out repeated imports
     new_import_statements = list(set(new_import_statements))
-    if futures:
+    if futures and not futures_import_found:
         new_import_statements.insert(0, b'from __future__ import annotations\n\n')
 
     # Remove old imports

--- a/tests/example_files/imports_template.py
+++ b/tests/example_files/imports_template.py
@@ -1,4 +1,8 @@
-x: list
+from __future__ import annotations
+
+from typing import List
+
+x: List
 
 
 def b(*, x: list[str]):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -5,7 +5,7 @@ result_path = 'result.py'
 expected_path = 'expected.py'
 
 
-def int_test(function_definition, expected, futures=False):
+def int_test(function_definition, expected, futures=False, expect_futures=True):
     with open(result_path, 'w+') as file:
         file.write(function_definition)
     with open(expected_path, 'w+') as file:
@@ -21,7 +21,9 @@ def int_test(function_definition, expected, futures=False):
         result = f.readlines()
 
     with open(expected_path, 'rb') as f:
-        expected = f.readlines() + [b'from __future__ import annotations\n'] if futures else []
+        expected = (
+            f.readlines() + [b'from __future__ import annotations\n'] if futures and expect_futures else []
+        )
 
     result = sorted(i for i in result if i.replace(b'\n', b''))
     expected = sorted(i for i in expected if i.replace(b'\n', b''))

--- a/tests/integration/test_futures_import.py
+++ b/tests/integration/test_futures_import.py
@@ -21,4 +21,4 @@ def test_no_duplicate_futures_annotations():
 
     Creating this to avoid this in the future.
     """
-    int_test(example, expected, futures=True)
+    int_test(example, expected)

--- a/tests/integration/test_futures_import.py
+++ b/tests/integration/test_futures_import.py
@@ -1,0 +1,24 @@
+from tests.integration import int_test
+
+example = """
+from __future__ import annotations
+
+from typing import List
+
+x: List
+"""
+
+expected = """
+from __future__ import annotations
+
+x: list
+"""
+
+
+def test_no_duplicate_futures_annotations():
+    """
+    Originally forgot to check for existing futures imports before adding a new one.
+
+    Creating this to avoid this in the future.
+    """
+    int_test(example, expected, futures=True)

--- a/tests/integration/test_futures_import.py
+++ b/tests/integration/test_futures_import.py
@@ -21,4 +21,4 @@ def test_no_duplicate_futures_annotations():
 
     Creating this to avoid this in the future.
     """
-    int_test(example, expected)
+    int_test(example, expected, futures=True, expect_futures=False)

--- a/tests/unit/test_find_annotations_in_file.py
+++ b/tests/unit/test_find_annotations_in_file.py
@@ -4,7 +4,7 @@ from .. import file_path
 
 
 def test_find_type_annotations_in_file():
-    annotations, _ = find_annotations_and_imports_in_file(
+    annotations, _, _ = find_annotations_and_imports_in_file(
         file_path / 'example_files/function_definition_template.py'
     )
     just_annotations = [i['annotation'] for i in annotations]

--- a/tests/unit/test_map_imports.py
+++ b/tests/unit/test_map_imports.py
@@ -9,22 +9,22 @@ def test_map_imports():
     """
     code_example = 'from typing import List'
     tree = ast.parse(code_example)
-    imports = map_imports(tree)
+    imports, _ = map_imports(tree)
     assert imports == [{'lineno': 1, 'end_lineno': 1, 'names': {'List'}}]
 
     code_example = 'from typing import List, Dict'
     tree = ast.parse(code_example)
-    imports = map_imports(tree)
+    imports, _ = map_imports(tree)
     assert imports == [{'lineno': 1, 'end_lineno': 1, 'names': {'List', 'Dict'}}]
 
     code_example = 'from typing import (\n\tList,\n\tDict\n\t)'
     tree = ast.parse(code_example)
-    imports = map_imports(tree)
+    imports, _ = map_imports(tree)
     assert imports == [{'lineno': 1, 'end_lineno': 4, 'names': {'List', 'Dict'}}]
 
     code_example = 'from \\\n\ttyping import (\n\tList,\n\tDict\n\t); from typing\\\n\t import Set'
     tree = ast.parse(code_example)
-    imports = map_imports(tree)
+    imports, _ = map_imports(tree)
     assert imports == [
         {'end_lineno': 5, 'lineno': 1, 'names': {'Dict', 'List'}},
         {'end_lineno': 6, 'lineno': 5, 'names': {'Set'}},
@@ -32,7 +32,7 @@ def test_map_imports():
 
     code_example = 'from \\\n\ttyping import (\n\tList,\n\tDict\n\t); from x\\\n\t import Set'
     tree = ast.parse(code_example)
-    imports = map_imports(tree)
+    imports, _ = map_imports(tree)
     assert imports == [{'end_lineno': 5, 'lineno': 1, 'names': {'Dict', 'List'}}]
 
 
@@ -42,5 +42,5 @@ def test_map_non_typing_imports():
     """
     code_example = 'from x import List'
     tree = ast.parse(code_example)
-    imports = map_imports(tree)
+    imports, _ = map_imports(tree)
     assert imports == []


### PR DESCRIPTION
Adds a check for existing `from __future__ import annotations` imports before adding new ones.