### PR TITLE
Consider module docstring while inserting future import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .venv
 *.pytest_cache
-.coverage
+.coverage*
 .idea
 *__pycache__
 dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: master
+    rev: main
     hooks:
       - id: black
         args: [ '--quiet' ]

--- a/README.md
+++ b/README.md
@@ -165,4 +165,5 @@ Both points are resolved by running flake8.
 
 ### Supporting the project
 
+
 Please leave a ✭ if this project helped you 👏 and contributions are always welcome!

--- a/src/upgrade_type_hints/checker.py
+++ b/src/upgrade_type_hints/checker.py
@@ -120,10 +120,7 @@ def map_imports(tree: ast.Module) -> tuple[list, bool]:
 def get_docstring_ends(item: ast.Module) -> int:
     """Get the position doc strings ends."""
     if ast.get_docstring(item):
-        try:
-            return item.body[0].end_lineno
-        except AttributeError:
-            return -1
+        return item.body[0].end_lineno
     else:
         return -1
 

--- a/src/upgrade_type_hints/main.py
+++ b/src/upgrade_type_hints/main.py
@@ -30,7 +30,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     for filename in args.filenames:
         # Fetch all typing imports and type annotations
-        annotation_list, imports, futures_import_found = find_annotations_and_imports_in_file(filename)
+        (
+            annotation_list,
+            imports,
+            futures_import_found,
+            future_import_insert_position,
+        ) = find_annotations_and_imports_in_file(filename)
 
         # Get all *relevant* type annotations (annotations we want to substitute)
         native_types, imported_types = check_if_types_need_substitution(annotation_list, imports)
@@ -47,6 +52,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 imported_types=imported_types,
                 imports_to_delete=imports_to_delete,
                 futures_import_found=futures_import_found,
+                future_import_insert_position=future_import_insert_position,
             )
             return_value = 1
 

--- a/src/upgrade_type_hints/update.py
+++ b/src/upgrade_type_hints/update.py
@@ -68,6 +68,7 @@ def update_file(
     imported_types: list,
     imports_to_delete: list,
     futures_import_found: bool,
+    future_import_insert_position: int,
 ) -> None:
     """
     Reads a file, removes imports and updates types, then writes back to it.
@@ -101,6 +102,13 @@ def update_file(
     for operation in imports_to_delete:
         content = remove_import(operation, content)
 
-    content = new_import_statements + content
+    if future_import_insert_position:
+        content = (
+            content[:future_import_insert_position]
+            + new_import_statements
+            + content[future_import_insert_position:]
+        )
+    else:
+        content = new_import_statements + content
     with open(filename, 'wb') as file:
         file.writelines(content)

--- a/src/upgrade_type_hints/update.py
+++ b/src/upgrade_type_hints/update.py
@@ -102,7 +102,7 @@ def update_file(
     for operation in imports_to_delete:
         content = remove_import(operation, content)
 
-    if future_import_insert_position:
+    if future_import_insert_position > 0:
         content = (
             content[:future_import_insert_position]
             + new_import_statements

--- a/tests/integration/test_futures_with_docstring.py
+++ b/tests/integration/test_futures_with_docstring.py
@@ -24,3 +24,22 @@ from __future__ import annotations
 x: list
     '''
     int_test(example, expected, futures=True, expect_futures=False)
+
+
+def test_no_docstring_with_missing_future():
+    example = '''from typing import List
+x: List
+'''
+
+    expected = '''from __future__ import annotations
+
+x: list
+    '''
+    int_test(example, expected, futures=True, expect_futures=False)
+
+
+def test_empty_file_with_missing_future():
+    example = '""'
+
+    expected = '''from __future__ import annotations'''
+    int_test(example, expected, futures=True, expect_futures=False)

--- a/tests/integration/test_futures_with_docstring.py
+++ b/tests/integration/test_futures_with_docstring.py
@@ -1,0 +1,26 @@
+from tests.integration import int_test
+
+
+def test_docstring_with_missing_future():
+    example = '''
+"""
+A multi-line
+docstring
+"""
+
+from typing import List
+
+x: List
+'''
+
+    expected = '''
+"""
+A multi-line
+docstring
+"""
+
+from __future__ import annotations
+
+x: list
+    '''
+    int_test(example, expected, futures=True, expect_futures=False)

--- a/tests/unit/test_find_annotations_in_file.py
+++ b/tests/unit/test_find_annotations_in_file.py
@@ -4,7 +4,7 @@ from .. import file_path
 
 
 def test_find_type_annotations_in_file():
-    annotations, _, _ = find_annotations_and_imports_in_file(
+    annotations, _, _, _ = find_annotations_and_imports_in_file(
         file_path / 'example_files/function_definition_template.py'
     )
     just_annotations = [i['annotation'] for i in annotations]

--- a/tests/unit/test_get_docstring_ends.py
+++ b/tests/unit/test_get_docstring_ends.py
@@ -36,10 +36,11 @@ test_data = [
         ),
         -1,
     ),
+    ('', -1),
 ]
 
 
-@pytest.mark.parametrize("source,expected_position", test_data)
+@pytest.mark.parametrize('source,expected_position', test_data)
 def test_get_docstring_ends(source, expected_position):
     tree = ast.parse(source)
     pos = get_docstring_ends(tree)

--- a/tests/unit/test_get_docstring_ends.py
+++ b/tests/unit/test_get_docstring_ends.py
@@ -1,0 +1,46 @@
+import ast
+from src.upgrade_type_hints.checker import get_docstring_ends
+import textwrap
+import pytest
+
+
+test_data = [
+    (
+        textwrap.dedent(
+            """
+        \"""
+        A multi-line
+        doc string
+        presented
+        \"""
+        from typing import List
+        a: List[int] = [1, 2]
+        """
+        ),
+        6,
+    ),
+    (
+        textwrap.dedent(
+            """
+    #! /usr/bin/env python
+    """
+        ),
+        -1,
+    ),
+    (
+        textwrap.dedent(
+            """
+    import requests
+    'is this docstring?'
+    """
+        ),
+        -1,
+    ),
+]
+
+
+@pytest.mark.parametrize("source,expected_position", test_data)
+def test_get_docstring_ends(source, expected_position):
+    tree = ast.parse(source)
+    pos = get_docstring_ends(tree)
+    assert pos == expected_position

--- a/tests/unit/test_get_future_import_insert_position.py
+++ b/tests/unit/test_get_future_import_insert_position.py
@@ -39,7 +39,7 @@ test_data = [
 ]
 
 
-@pytest.mark.parametrize("source,expected_position", test_data)
+@pytest.mark.parametrize('source,expected_position', test_data)
 def test_get_docstring_ends(source, expected_position):
     tree = ast.parse(source)
     pos = get_future_import_insert_position(tree)

--- a/tests/unit/test_get_future_import_insert_position.py
+++ b/tests/unit/test_get_future_import_insert_position.py
@@ -1,0 +1,46 @@
+import ast
+from src.upgrade_type_hints.checker import get_future_import_insert_position
+import textwrap
+import pytest
+
+
+test_data = [
+    (
+        textwrap.dedent(
+            """
+        \"""
+        A multi-line
+        doc string
+        presented
+        \"""
+        from typing import List
+        a: List[int] = [1, 2]
+        """
+        ),
+        6,
+    ),
+    (
+        textwrap.dedent(
+            """
+    #! /usr/bin/env python
+    """
+        ),
+        -1,
+    ),
+    (
+        textwrap.dedent(
+            """
+    import requests
+    'is this docstring?'
+    """
+        ),
+        -1,
+    ),
+]
+
+
+@pytest.mark.parametrize("source,expected_position", test_data)
+def test_get_docstring_ends(source, expected_position):
+    tree = ast.parse(source)
+    pos = get_future_import_insert_position(tree)
+    assert pos == expected_position


### PR DESCRIPTION
### Summary

When the python file consists of module docstring, the formatter inserts the `from __future__ import annotation` on the top of the docstring. 

## Previous Behavior

### Source

```python
#! /usr/env/bin python
"""don't touch the doc string

multi line boss
"""
from typing import List

a: List[int] = [1, 2]


def foo():
    """I'm a doc string"""
    pass
```
### Generated

```python
from __future__ import annotations


#! /usr/env/bin python
"""don't touch the doc string

multi line boss
"""

a: list[int] = [1, 2]


def foo():
    """I'm a doc string"""
```

The PR adds a function to find the module docstring. It will insert `future` import after the module docstring.
